### PR TITLE
Signing the jars and publish to sonatype

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ without having to implement it themselves. The API is based on **Vert.x**.
 ```xml
 <dependency>
     <groupId>de.tarent.telekom.cot</groupId>
-    <artifactId>nbiot-mqtt</artifactId>
-    <version>version-number</version>    
+    <artifactId>cot-mqtt-sdk</artifactId>
+    <version>com.telekom.m2m.cot</version>    
 </dependency>
 ```
  

--- a/asciidoc/README.adoc
+++ b/asciidoc/README.adoc
@@ -14,8 +14,8 @@ contact team MasCoT at telekom-mascot@lists.tarent.de_
 [source,xml]
 ----
 <dependency>
-    <groupId>de.tarent.telekom.cot</groupId>
-    <artifactId>nbiot-mqtt</artifactId>
+    <groupId>com.telekom.m2m.cot</groupId>
+    <artifactId>cot-mqtt-sdk</artifactId>
     <version>version-number</version> <!--1-->
 </dependency>
 ----

--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ apply plugin: "net.linguica.maven-settings"
 apply plugin: "maven-publish"
 apply plugin: "org.sonarqube"
 apply plugin: "jacoco"
+apply plugin: "signing"
 
 ext {
     vertxVersion = '3.5.1'
@@ -110,6 +111,11 @@ task wrapper(type: Wrapper) {
     gradleVersion = '4.0'
 }
 
+signing {
+    sign configurations.archives
+}
+
+
 publishing {
     publications {
         mavenJava(MavenPublication) {
@@ -132,6 +138,14 @@ publishing {
         maven {
             name "${project.version.endsWith('-SNAPSHOT') ? 'nbiot-snapshots':'nbiot-releases'}"
             url "${wBenchNexusUrl}/content/repositories/${project.version.endsWith('-SNAPSHOT') ? 'nbiot-snapshots':'nbiot-releases'}"
+        }
+        maven {
+            name "${project.version.endsWith('-SNAPSHOT') ? 'snapshots':'releases'}"
+            url "${sonatypeUrl}/content/repositories/${project.version.endsWith('-SNAPSHOT') ? 'snapshots':'releases'}"
+            credentials {
+                username 'username'
+                password 'password'
+            }
         }
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,4 @@
 wBenchNexusUrl=http://infinity-wbench.psst.t-online.corp/nexus
+sonatypeUrl=https://oss.sonatype.org
 version=1.0.0
 nbiotMqttVersion=${version}


### PR DESCRIPTION
Include sonatype repo in publishing

Requirements :
Certificates to sign the jars have to be imported in gnupg secring
Authentication against sonatype is requeired, credentials have to be set in build.gradle

look at https://central.sonatype.org/pages/ossrh-guide.html (we using the maven-publish plugin instead maven-plugin, but gradle.properties
changes are important))

Dependencies now 
<dependency>
  <groupId>com.telekom.m2m.cot</groupId>
  <artifactId>cot-mqtt-sdk</artifactId>
  <version>1.0.0</version>
</dependency>